### PR TITLE
hide log trace

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "deploy": "ng deploy --base-href=/angular-tour-of-heroes/ --no-silent"
+    "deploy": "ng deploy --base-href=/angular-tour-of-heroes/"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
For testing purposes, the log trace was enabled in the deployment.